### PR TITLE
Fixing QKVAttentionLegacy to be compatible with the provided checkpoints / Adding Xformers' ScaledDotProduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For single-step diffusion model sampling, our new model, Consistency Trajectory 
     python -m pip install blobfile tqdm numpy scipy pandas Cython piq==0.7.0
     python -m pip install joblib==0.14.0 albumentations==0.4.3 lmdb clip@git+https://github.com/openai/CLIP.git pillow
     python -m pip install flash-attn --no-build-isolation
+    python -m pip install xformers
     python -m pip install mpi4py
     python -m pip install nvidia-ml-py3 timm==0.4.12 legacy dill nvidia-ml-py3
     ```

--- a/code/cm/script_util.py
+++ b/code/cm/script_util.py
@@ -175,6 +175,7 @@ def model_and_diffusion_defaults(data_name):
         use_scale_shift_norm=True,
         resblock_updown=True,
         use_new_attention_order=False,
+        attention_type='flash',
         learn_sigma=False,
         weight_schedule="uniform",
         weight_schedule_multiplier=1.,
@@ -299,6 +300,7 @@ def create_model_and_diffusion(args, feature_extractor=None, discriminator_featu
             use_fp16=args.use_fp16,
             use_new_attention_order=args.use_new_attention_order,
             training_mode=('teacher' if teacher else args.training_mode),
+            attention_type=args.attention_type,
         )
     diffusion = KarrasDenoiser(
         args=args, schedule_sampler=schedule_sampler,
@@ -327,6 +329,7 @@ def create_model(
     use_fp16=False,
     use_new_attention_order=False,
     training_mode='',
+    attention_type='flash',
 ):
     if channel_mult == "":
         if image_size == 512:
@@ -365,6 +368,7 @@ def create_model(
         resblock_updown=resblock_updown,
         use_new_attention_order=use_new_attention_order,
         training_mode=training_mode,
+        attention_type=attention_type,
     )
 
 

--- a/code/cm/unet.py
+++ b/code/cm/unet.py
@@ -515,10 +515,9 @@ class QKVAttentionLegacy(nn.Module):
         bs, width, length = qkv.shape
         assert width % (3 * self.n_heads) == 0
         ch = width // (3 * self.n_heads)
-        q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
-        # q, k, v = rearrange(
-        #     qkv, "b (three h d) s -> (b h) (three d) s", three=3, h=self.n_heads
-        # ).split(ch, dim=1)
+        q, k, v = rearrange(
+            qkv, "b (three h d) s -> (b h) (three d) s", three=3, h=self.n_heads
+        ).split(ch, dim=1)
         scale = 1 / math.sqrt(math.sqrt(ch))
         weight = th.einsum(
             "bct,bcs->bts", q * scale, k * scale

--- a/code/cm/unet.py
+++ b/code/cm/unet.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from einops import rearrange
 from flash_attn.flash_attn_interface import flash_attn_varlen_qkvpacked_func
 from flash_attn.bert_padding import unpad_input, pad_input
+from xformers.components.attention import ScaledDotProduct
 
 from .fp16_util import convert_module_to_f16, convert_module_to_f32
 from .nn import (
@@ -309,6 +310,8 @@ class AttentionBlock(nn.Module):
         self.attention_type = attention_type
         if attention_type == "flash":
             self.attention = QKVFlashAttention(channels, self.num_heads)
+        elif attention_type == 'xformer':
+            self.attention = XformersAttention(self.num_heads)
         else:
             # split heads before split qkv
             self.attention = QKVAttentionLegacy(self.num_heads)
@@ -478,6 +481,20 @@ def count_flops_attn(model, _x, y):
     matmul_ops = 2 * b * (num_spatial**2) * c
     model.total_ops += th.DoubleTensor([matmul_ops])
 
+class XformersAttention(nn.Module):
+    def __init__(self, num_heads):
+        super().__init__()
+        self.attention = ScaledDotProduct()
+        self.num_heads = num_heads
+    
+    def forward(self, qkv, attn_mask=None):
+        """
+        input : qkv
+        """
+        q, k, v = rearrange(
+            qkv, "b (three h d) s -> (b h) three s d", three=3, h=self.num_heads
+        ).chunk(3, dim=1)
+        return rearrange(self.attention(q.squeeze(1), k.squeeze(1), v.squeeze(1), attn_mask), "(b h) s d -> b (h d) s", h=self.num_heads)
 
 class QKVAttentionLegacy(nn.Module):
     """
@@ -499,6 +516,9 @@ class QKVAttentionLegacy(nn.Module):
         assert width % (3 * self.n_heads) == 0
         ch = width // (3 * self.n_heads)
         q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
+        # q, k, v = rearrange(
+        #     qkv, "b (three h d) s -> (b h) (three d) s", three=3, h=self.n_heads
+        # ).split(ch, dim=1)
         scale = 1 / math.sqrt(math.sqrt(ch))
         weight = th.einsum(
             "bct,bcs->bts", q * scale, k * scale


### PR DESCRIPTION
This is a pull request to address the issue mentioned in #5. Additionally, `ScaledDotProduct()` from xformers is added as an option, which could be selected by passing `--attention_type=xformer`.